### PR TITLE
feat: include `constructorParams` into `DeployContract` event

### DIFF
--- a/contracts/global/BytecodeRepository.sol
+++ b/contracts/global/BytecodeRepository.sol
@@ -194,7 +194,7 @@ contract BytecodeRepository is ImmutableOwnableTrait, SanityCheckTrait, IBytecod
         }
 
         _deployedContractBytecodeHashes[newContract] = bytecodeHash;
-        emit DeployContract(bytecodeHash, cType, ver, newContract);
+        emit DeployContract(bytecodeHash, cType, ver, newContract, constructorParams);
 
         try Ownable(newContract).transferOwnership(msg.sender) {} catch {}
     }

--- a/contracts/interfaces/IBytecodeRepository.sol
+++ b/contracts/interfaces/IBytecodeRepository.sol
@@ -19,7 +19,11 @@ interface IBytecodeRepository is IVersion, IImmutableOwnableTrait {
     event AllowContract(bytes32 indexed bytecodeHash, bytes32 indexed contractType, uint256 indexed version);
     event AuditBytecode(bytes32 indexed bytecodeHash, address indexed auditor, string reportUrl, bytes signature);
     event DeployContract(
-        bytes32 indexed bytecodeHash, bytes32 indexed contractType, uint256 indexed version, address contractAddress
+        bytes32 indexed bytecodeHash,
+        bytes32 indexed contractType,
+        uint256 indexed version,
+        address contractAddress,
+        bytes constructorParams
     );
     event ForbidContract(bytes32 indexed bytecodeHash, bytes32 indexed contractType, uint256 indexed version);
     event ForbidInitCode(bytes32 indexed initCodeHash);

--- a/contracts/test/global/BytecodeRepository.unit.t.sol
+++ b/contracts/test/global/BytecodeRepository.unit.t.sol
@@ -89,7 +89,9 @@ contract BytecodeRepositoryUnitTest is Test {
         assertFalse(bcr.isDeployedFromRepository(expectedAddr));
 
         vm.expectEmit(true, true, true, true);
-        emit IBytecodeRepository.DeployContract(publicBytecodeHash, bytes32("PUBLIC::MOCK"), 300, expectedAddr);
+        emit IBytecodeRepository.DeployContract(
+            publicBytecodeHash, bytes32("PUBLIC::MOCK"), 300, expectedAddr, constructorParams
+        );
 
         vm.expectCall(expectedAddr, abi.encodeWithSignature("transferOwnership(address)", address(this)));
 


### PR DESCRIPTION
This change allows to build automatic contracts verification system based on events emitted by the BCR.